### PR TITLE
Add fast forward audio config Gambatte.opt 

### DIFF
--- a/Gambatte.opt
+++ b/Gambatte.opt
@@ -15,6 +15,7 @@
 ### [gambatte_up_down_allowed]           :[disabled]                     :[enabled|disabled]
 ### [gambatte_turbo_period]              :[4]                            :[4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63|64|65|66|67|68|69|70|71|72|73|74|75|76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94|95|96|97|98|99|100|101|102|103|104|105|106|107|108|109|110|111|112|113|114|115|116|117|118|119|120]
 ### [gambatte_rumble_level]              :[0]                            :[0|1|2|3|4|5|6|7|8|9|10]
+### [gambatte_fast_forward_audio]        :[disabled]                     :[enabled|disabled]
 gambatte_audio_resampler = "sinc"
 gambatte_dark_filter_level = "0"
 gambatte_gb_bootloader = "enabled"
@@ -32,3 +33,4 @@ gambatte_mix_frames = "disabled"
 gambatte_rumble_level = "0"
 gambatte_turbo_period = "4"
 gambatte_up_down_allowed = "disabled"
+gambatte_fast_forward_audio = "disabled"


### PR DESCRIPTION
# Description of the Change
This PR:
- adds new configuration property for Gambatte fast forward audio

# How to Test
You can enable/disable audio during fast forward by configuring
```
gambatte_fast_forward_audio: "enabled"
``` 
or
```
gambatte_fast_forward_audio: "disabled"
``` 

in cores/config/Gambatte.opt

[Uploading GB300_GAMBATTE_FF_SM_DASH.zip…]()
