### PR TITLE
Updated Frodo.opt for added core options

### DIFF
--- a/Frodo.opt
+++ b/Frodo.opt
@@ -1,3 +1,8 @@
 ### [frodo_resolution]:[384x288]:[384x288|400x300|640x480|832x576|960x720|1024x768|1024x1024]
 frodo_resolution = "384x288"
+### [frodo_frameskip]:[0]:[auto|0|1|2|3|4|5]
 frodo_frameskip = "1"
+### [frodo_1541emul]:[true]:[true|false]
+frodo_1541emul = "false"
+### [frodo_overscan]:[none]:[none|auto|small|medium|large]
+frodo_overscan = "none"

--- a/Frodo.opt
+++ b/Frodo.opt
@@ -3,6 +3,6 @@ frodo_resolution = "384x288"
 ### [frodo_frameskip]:[0]:[auto|0|1|2|3|4|5]
 frodo_frameskip = "1"
 ### [frodo_1541emul]:[true]:[true|false]
-frodo_1541emul = "false"
+frodo_1541emul = "true"
 ### [frodo_overscan]:[none]:[none|auto|small|medium|large]
 frodo_overscan = "none"


### PR DESCRIPTION
- frodo_1541emul: [true]:[true|false]
- frodo_overscan: [none]:[none|auto|small|medium|large]

# Description of the Change
Updated Frodo.opt for added core options

# How to Test
Change "frodo_overscan" from "none" to "auto" to see the cropping feature.
Change "frodo_1541emul" from "true" to "false" to see the d64 loading speed improvement (less games compatibility)